### PR TITLE
fix: skip models whose details['latest_version'] is empty

### DIFF
--- a/llm_replicate/__init__.py
+++ b/llm_replicate/__init__.py
@@ -193,6 +193,9 @@ def register_models(register):
     if fetch_models_path.exists():
         models = json.loads(fetch_models_path.read_text())
         for details in models:
+            if not details["latest_version"]:
+                print(f"Skipping model '{details['name']}'")
+                continue
             register(
                 ReplicateModel(
                     owner=details["owner"],


### PR DESCRIPTION
Signed-off-by: thiswillbeyourgithub <26625900+thiswillbeyourgithub@users.noreply.github.com>

Fix to #18

I don't know if this is still relevant as my version was 0.2 and not 0.3
